### PR TITLE
Prevent scanline from running if it's not targeting the same canvas size it started at

### DIFF
--- a/mandelbrot.js
+++ b/mandelbrot.js
@@ -182,6 +182,8 @@ function draw(lookAt, zoom, pickColor)
   function render()
   {
     var start  = (new Date).getTime();
+    var startHeight = canvas.height;
+    var startWidth = canvas.width;
     var lastUpdate = start;
     var updateTimeout = 250.0; // ms
     var pixels = 0;
@@ -190,6 +192,7 @@ function draw(lookAt, zoom, pickColor)
 
     var scanline = function()
     {
+      if(startHeight != canvas.height || startWidth != canvas.width) { return; }
       drawLine(y, 0, xRange[0], dx);
       y += dy;
       pixels += canvas.width;


### PR DESCRIPTION
If you have draw being called again before the previous call to it has finished rendering, this will prevent lines which don't fit in the active canvas context from being drawn.  Your example ties draw to pressing a button so it could be hard to see this have any significance, but I'm playing around with one where I tie draw to resize and it was getting really messy without this check in there.  Doesn't seem to impact performance in any significant way.
